### PR TITLE
Bumping the version to the new_version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,6 +10,7 @@ serialize =
 [bumpversion:file:src/polyphy/_version.py]
 
 [bumpversion:file:setup.py]
+message = Bump version: {new_version}
 
 [bumpversion:part:release]
 optional_value = gamma


### PR DESCRIPTION
This configuration ensures that when bumpversion updates the version in setup.py, it creates a commit with the message "Bump version: {new_version}", where {new_version} is the newly bumped version number.