### PR TITLE
Purging package cache macos_python.yml

### DIFF
--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -22,8 +22,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        python -m pip cache purge
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install --no-cache-dir flake8 pytest
         pip install -r requirements.txt
         pip install . -U
     - name: Lint with flake8


### PR DESCRIPTION
To fix the error:

ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.