### PR TITLE
Added exception logging with stack trace

### DIFF
--- a/src/polyphy/utils/logger.py
+++ b/src/polyphy/utils/logger.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 import logging
 import time
+from logging.handlers import RotatingFileHandler
 
 
 class Logger:
@@ -45,6 +46,7 @@ class Logger:
     # FILE:
     file_logger = logging.getLogger("file")
     file_handler = logging.FileHandler("polyphy.log")
+    file_handler = RotatingFileHandler("polyphy.log", maxBytes=1024*1024, backupCount=3)
     file_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     file_handler.setFormatter(file_formatter)
     file_logger.addHandler(file_handler)
@@ -64,14 +66,12 @@ class Logger:
 
     @staticmethod
     def logException(level, exception, *msg) -> None:
+        log_msg = " ".join(map(str, msg))
+        log_msg += f"\nException: {repr(exception)}"
+        log_msg += f"\nStack Trace: {traceback.format_exc()}"
         
-    # Construct log message with exception info
-    log_msg = " ".join(map(str, msg))
-    log_msg += f"\nException: {repr(exception)}"
-    log_msg += f"\nStack Trace: {traceback.format_exc()}"
-    
-    # Log to console
-    Logger.logToStdOut(level, log_msg)
-    
-    # Log to file
-    Logger.logToFile(level, log_msg)
+        # Log to console
+        Logger.logToStdOut(level, log_msg)
+        
+        # Log to file
+        Logger.logToFile(level, log_msg)

--- a/src/polyphy/utils/logger.py
+++ b/src/polyphy/utils/logger.py
@@ -70,9 +70,7 @@ class Logger:
         log_msg = " ".join(map(str, msg))
         log_msg += f"\nException: {repr(exception)}"
         log_msg += f"\nStack Trace: {traceback.format_exc()}"
-        
         # Log to console
         Logger.logToStdOut(level, log_msg)
-        
         # Log to file
         Logger.logToFile(level, log_msg)

--- a/src/polyphy/utils/logger.py
+++ b/src/polyphy/utils/logger.py
@@ -61,3 +61,17 @@ class Logger:
         Logger.file_logger.setLevel(Logger.log_level.get(level, logging.INFO))
         res = " ".join(map(str, msg))
         Logger.file_log_functions.get(level, Logger.file_logger.info)(res)
+
+    @staticmethod
+    def logException(level, exception, *msg) -> None:
+        
+    # Construct log message with exception info
+    log_msg = " ".join(map(str, msg))
+    log_msg += f"\nException: {repr(exception)}"
+    log_msg += f"\nStack Trace: {traceback.format_exc()}"
+    
+    # Log to console
+    Logger.logToStdOut(level, log_msg)
+    
+    # Log to file
+    Logger.logToFile(level, log_msg)

--- a/src/polyphy/utils/logger.py
+++ b/src/polyphy/utils/logger.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 import logging
 import time
+import traceback
 from logging.handlers import RotatingFileHandler
 
 


### PR DESCRIPTION
- Added logException method to capture exceptions, including their `stack` traces and optional messages.
- Exceptions are logged to both console and file using existing `logToStdOut` and `logToFile` methods.